### PR TITLE
fix: build and deploy the docs site from CI instead of by hand

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,77 @@
+name: Build and deploy docs
+
+# Builds the MkDocs site and publishes it to GitHub Pages.
+#
+# This replaces the old manual ritual of building locally and copying the
+# output onto the gh-pages branch. See DEPLOYMENT.md for why that broke.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never let two deploys race each other onto the live site.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      # --strict turns MkDocs warnings (broken links, missing files, bad nav
+      # entries) into build failures. A loud failure here is the whole point:
+      # the previous setup always reported success while shipping stale HTML.
+      - name: Build site
+        run: mkdocs build --strict
+
+      # site/CNAME is what tells GitHub Pages that this repo owns
+      # docs.superinsight.me. It comes from docs/CNAME, which MkDocs copies
+      # verbatim. If that file is ever deleted the custom domain 404s, so fail
+      # the build instead of publishing a site that takes docs offline.
+      - name: Verify custom domain file survived the build
+        run: |
+          if [ ! -f site/CNAME ]; then
+            echo "::error::site/CNAME is missing. Restore docs/CNAME or the custom domain will break."
+            exit 1
+          fi
+          if ! grep -qx 'docs.superinsight.me' site/CNAME; then
+            echo "::error::site/CNAME does not contain docs.superinsight.me. Got: $(cat site/CNAME)"
+            exit 1
+          fi
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
+  deploy:
+    # Pull requests build and validate only; they never touch the live site.
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,151 @@
+# Deployment
+
+How https://docs.superinsight.me is built and published, and why it silently
+served six-month-old content until August 2026.
+
+## How it works now
+
+```
+docs/*.md  ──►  main  ──►  GitHub Actions (mkdocs build)  ──►  GitHub Pages
+                                                                    │
+                                          superinsight.github.io ◄──┘
+                                                    │
+                              Cloudflare CNAME (proxied)
+                                                    │
+                                      docs.superinsight.me
+```
+
+Merge to `main` and you are done. `.github/workflows/deploy.yml` installs the
+pinned dependencies, runs `mkdocs build --strict`, and publishes the generated
+`site/` directory. There is nothing to build by hand and nothing to copy.
+
+The `gh-pages` branch is **no longer used**. Do not merge into it, do not push
+to it, do not treat it as the source of truth.
+
+## Why the site went stale
+
+### Symptom
+
+Between February and August 2026 the docs were edited repeatedly. Every
+deployment reported success. The live site never changed.
+
+### Root cause
+
+The site is MkDocs, so `docs/*.md` is source that has to be *compiled* into
+HTML. GitHub Pages was configured in legacy mode, pointed at the `gh-pages`
+branch, which means it publishes whatever is already sitting on that branch —
+it does not know what MkDocs is and never ran it.
+
+Building was therefore a manual step, performed on someone's laptop and
+committed as pre-built HTML. The old README documented it:
+
+```
+mkdocs build --site-dir public
+mv public ../
+git checkout gh-pages
+cp -R ../public/ ./
+git add . && git commit && git push
+```
+
+When that step was skipped, the commits that reached `gh-pages` were
+`Merge branch 'main' into gh-pages` — which brings across the Markdown
+*source* but leaves the compiled HTML at the branch root untouched. The result:
+
+| File on `gh-pages`                  | Last changed |
+| ----------------------------------- | ------------ |
+| `docs/` (Markdown source)           | 2026-08-06   |
+| `index.html` (**the page served**)  | 2026-02-02   |
+
+Every edit landed on the branch. None of it reached the rendered page.
+
+### Why nobody noticed
+
+Three things hid the failure:
+
+1. **The build was always green.** The `pages build and deployment` run in the
+   Actions tab is GitHub's own built-in job, not ours — the repo had no
+   `.github/workflows` directory at all. That job's only responsibility is to
+   copy `gh-pages` to the CDN, and it did that flawlessly. It reported success
+   for publishing content that was six months old.
+2. **The deploy timestamp moved.** Each re-run refreshed the `Last-Modified`
+   header and produced a new deployment record, so the site looked freshly
+   published.
+3. **`gh-pages` looked correct.** Because `cp -R` copies over the top without
+   deleting, and because merges added more, the branch accumulated both the
+   Markdown source and the compiled output side by side. Browsing it showed the
+   latest `docs/*.md`, which read as "the new content is deployed."
+
+### The general lesson
+
+A deploy pipeline that reports success without verifying that output changed is
+indistinguishable from one that works. The fix is not "remember to run the
+build" — it is removing the human step entirely, which is what the workflow now
+does.
+
+## The CNAME landmine
+
+`docs.superinsight.me` is a Cloudflare CNAME to `superinsight.github.io`. That
+hostname is GitHub's shared entry point for every Pages site in the org and
+points at no repository in particular:
+
+```
+GET https://superinsight.github.io/                    →  404
+GET same host, with header "Host: docs.superinsight.me" →  200
+```
+
+GitHub routes on the `Host` header: it looks for the repository whose published
+`CNAME` file contains `docs.superinsight.me` and serves that one. So the file
+`CNAME` at the root of the published site — not the DNS record — is what binds
+this repository to the domain.
+
+MkDocs copies everything under `docs/` into `site/` verbatim, so `docs/CNAME`
+is what puts `CNAME` into the published output. **If `docs/CNAME` is deleted,
+the custom domain stops resolving to this repo and the docs 404.** The workflow
+asserts the file survives every build, and fails rather than publishing a site
+that would take docs offline.
+
+This is also why the old `mkdocs gh-deploy` route was dangerous: it replaces the
+branch wholesale, and before `docs/CNAME` existed it would have dropped the
+domain binding.
+
+## Working on the docs
+
+```bash
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+mkdocs serve          # http://127.0.0.1:8000, live reload
+```
+
+Before opening a PR, reproduce what CI does:
+
+```bash
+mkdocs build --strict
+```
+
+`--strict` promotes MkDocs warnings to errors, so broken internal links,
+missing images and stale `nav:` entries fail the build. Pull requests run this
+check without deploying; only merges to `main` publish.
+
+Dependencies in `requirements.txt` are pinned. An unpinned upstream release
+breaking the live docs site is not a failure mode worth keeping — bump them
+deliberately, in a PR, where the strict build can vet the change.
+
+## Troubleshooting
+
+**A change is merged but the live page looks unchanged.** Check the
+`Build and deploy docs` workflow run for that commit. If it is green, the
+content is published and you are seeing a cache — hard-reload, or purge the
+Cloudflare cache for the affected path.
+
+**The build fails on a link or image.** `--strict` is doing its job; the error
+names the file and the target. Fix the reference rather than removing the flag.
+
+**The site 404s entirely.** Confirm `docs/CNAME` still exists and still reads
+`docs.superinsight.me`, then confirm the Cloudflare record for `docs` still
+points at `superinsight.github.io`.
+
+**`deploy-pages` fails with a configuration error.** The repository's Pages
+source must be set to **GitHub Actions**
+(Settings → Pages → Build and deployment → Source), not the legacy
+`gh-pages` branch.

--- a/README.md
+++ b/README.md
@@ -1,41 +1,43 @@
 # superinsight-app-doc
 
-Documentation for superinsight app
+Documentation for the Superinsight app, published to
+https://docs.superinsight.me.
 
-## Installation virtual environment
-```
-python3.11 -m pip install virtualenv
-python3.11 -m virtualenv -p python3 .venv
-```
+Built with [MkDocs](https://www.mkdocs.org/) and
+[Material for MkDocs](https://squidfunk.github.io/mkdocs-material/).
 
-## Activate the virtual environment
+## Local setup
 
-```
+```bash
+python3.11 -m venv .venv
 source .venv/bin/activate
-```
-
-## Install dependencies
-
-```
 pip install -r requirements.txt
 ```
 
+## Run locally
 
-## Run Locally
-
-```
+```bash
 mkdocs serve
 ```
 
-### Build folder and Copy to gh-pages branch
+Then open http://127.0.0.1:8000. The site reloads as you edit.
 
+## Publishing
+
+**Merge to `main`.** That is the whole process.
+
+A GitHub Actions workflow builds the site and deploys it to GitHub Pages on
+every push to `main`. There is no manual build step, and the `gh-pages` branch
+is no longer used — do not merge or push to it.
+
+Before opening a PR, run the same check CI runs:
+
+```bash
+mkdocs build --strict
 ```
-mkdocs build --site-dir public
-mv public ../
-git checkout gh-pages
-cp -R ../public/ ./
-rm -rf ../public
-git add .
-git commit -m "xxxxxx"
-git push
-```
+
+This fails on broken links, missing images and stale `nav:` entries. Pull
+requests run it automatically without deploying.
+
+See [DEPLOYMENT.md](DEPLOYMENT.md) for how the pipeline works, why the manual
+process used to publish stale pages, and how to troubleshoot a deploy.

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.superinsight.me

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
-mkdocs
-mkdocs-material
-mkdocs-i18n
-mkdocs-static-i18n
-mkdocs-pdf
+# Pinned so an upstream release cannot silently break the live docs site.
+# Bump deliberately in a PR; the strict build in CI vets the change.
+mkdocs==1.6.1
+mkdocs-material==9.7.7
+mkdocs-material-extensions==1.3.1
+mkdocs-i18n==0.4.6
+mkdocs-static-i18n==1.3.1
+mkdocs-pdf==0.1.2
+pymdown-extensions==10.21.3


### PR DESCRIPTION
## Problem

`docs.superinsight.me` has been serving HTML compiled on **2026-02-02** even though the Markdown sources were updated through 2026-08-06. Vinny reported the symptom on 2026-08-11: repeated successful deploys, no change on the live page.

The live page and the published branch match byte for byte, so Pages was doing its job correctly — it was publishing content nobody had rebuilt.

| File on `gh-pages`                 | Last changed |
| ---------------------------------- | ------------ |
| `docs/` (Markdown source)          | 2026-08-06   |
| `index.html` (**the page served**) | 2026-02-02   |

## Root cause

Pages was configured in legacy mode against `gh-pages`, which publishes that branch verbatim and never runs MkDocs. Compiling was a manual step done on a laptop and committed as pre-built HTML, per the old README:

```
mkdocs build --site-dir public
git checkout gh-pages
cp -R ../public/ ./
```

When that step was skipped, `Merge branch 'main' into gh-pages` brought the Markdown source across but left the compiled HTML at the branch root untouched.

Three things hid the failure:

1. **The build was always green.** The `pages build and deployment` run is GitHub's built-in job, not ours — the repo had no `.github/workflows` at all. Copying `gh-pages` to the CDN is its entire responsibility, and it did that perfectly, for six-month-old content.
2. **The deploy timestamp moved,** so the site looked freshly published.
3. **`gh-pages` looked correct.** `cp -R` copies over the top without deleting, so the branch accumulated the Markdown source and the compiled output side by side — browsing it showed the latest `.md` files, which read as "the new content is deployed."

## Changes

- **`.github/workflows/deploy.yml`** — builds on PRs, builds and deploys on pushes to `main`. Merging to `main` becomes the entire publishing process.
- **`mkdocs build --strict`** — broken links, missing images and stale `nav:` entries now fail the build. A pipeline that reports success without verifying its output is indistinguishable from one that works; this makes failures loud.
- **`docs/CNAME`** — MkDocs copies `docs/` into `site/` verbatim, so this puts `CNAME` into the published output. GitHub Pages routes on the `Host` header and looks up the repo whose published `CNAME` matches, so that file — not the DNS record — is what binds this repo to the domain. Without it the domain 404s. CI asserts it survives every build.
- **`requirements.txt`** — pinned. An unpinned upstream release breaking the live docs site is not a failure mode worth keeping.
- **`DEPLOYMENT.md`** — the pipeline, this post-mortem, the `CNAME` constraint, and troubleshooting.
- **`README.md`** — replaces the manual `gh-pages` copy ritual with the current flow.

## Required before this takes effect

Settings → Pages → Build and deployment → **Source: GitHub Actions** (currently legacy `gh-pages`).

If this merges before the setting is flipped, `deploy-pages` fails with a configuration error and the site keeps serving what it serves today — no downtime, just a red run.

## Rollback

This PR is a configuration change, not a content change, and it is reversible in one step.

Nothing here writes to `gh-pages`. The new workflow uploads the built site as an artifact and never pushes to a branch, so `gh-pages` freezes exactly as it is today and remains a complete, serveable copy of the current live site. **Do not delete it.** It is also pinned independently at `gh-pages-snapshot-20260814` (`c2260b68`) in case the branch is ever force-pushed.

To revert, point Pages back at the branch:

```bash
gh api -X PUT repos/superinsight/superinsight-app-doc/pages \
  --input - <<'JSON'
{"build_type":"legacy","source":{"branch":"gh-pages","path":"/"}}
JSON
```

The site returns to its current content within a minute or two. No rebuild, no revert commit, and the custom domain is unaffected because `gh-pages` still carries its own `CNAME` file.

Reverting the merge is optional and only needed to stop future pushes to `main` from redeploying.

## Verification

- `mkdocs build --strict` passes clean against the pinned dependencies (exit 0)
- `site/CNAME` is produced and contains `docs.superinsight.me`
- The freshly built `index.html` is 31,418 bytes vs the 21,517 bytes currently live, confirming a rebuild genuinely changes the published page
- This PR's own CI run is green, with the upload and deploy steps correctly skipped for `pull_request`

## Test plan

- [ ] Review the rebuilt site locally (`mkdocs serve`) — six months of unpublished content lands at once, so it is worth a look before it goes live
- [ ] Flip the Pages source to GitHub Actions
- [ ] Merge, confirm the deploy job publishes
- [ ] Load `https://docs.superinsight.me` and verify Vinny's July/August content is live
- [ ] Confirm the custom domain still resolves (the `CNAME` handover is the one real risk)
- [ ] Leave `gh-pages` and `gh-pages-snapshot-20260814` in place as the rollback path; revisit deleting them only after the new pipeline has shipped a few changes uneventfully